### PR TITLE
Support for calling Gitana process without config file

### DIFF
--- a/extractor/git_tracker/git2db_main.py
+++ b/extractor/git_tracker/git2db_main.py
@@ -36,7 +36,24 @@ PROCESSES = 30 #30 len(REFERENCES)
 
 class Git2DbMain():
 
-    def __init__(self, project_name, db_name, repo_name, git_repo_path, before_date, import_last_commit, import_type):
+    def __init__(self, project_name, db_name, repo_name, git_repo_path, before_date, import_last_commit, import_type,
+                 config):
+        """
+        This constructor creates a new InitDbSchema instance.
+
+        The config object has to comply with an structure similar to:
+
+        CONFIG = {
+            'user': 'DB_USER',
+            'password': 'DB_PASS',
+            'host': 'DB_HOST',
+            'port': 'DB_PORT',
+            'raise_on_warnings': False,
+            'buffered': True
+        }
+
+        :param config: The config object with the fields previously described
+        """
         self.create_log_folder(LOG_FOLDER)
         LOG_FILENAME = LOG_FOLDER + "/git2db_main"
         self.delete_previous_logs(LOG_FOLDER)
@@ -57,7 +74,7 @@ class Git2DbMain():
         self.import_type = import_type
         self.querier = GitQuerier(git_repo_path, self.logger)
 
-        self.cnx = mysql.connector.connect(**config_db.CONFIG)
+        self.cnx = mysql.connector.connect(**config.CONFIG)
         self.set_database()
 
     def create_log_folder(self, name):
@@ -116,7 +133,7 @@ class Git2DbMain():
             if REFERENCES:
                 if reference[0] in REFERENCES:
                     p = Popen(['python', 'git2db_reference.py', str(repo_id), reference[0], self.db_name, self.git_repo_path,
-                              str(self.before_date), str(self.import_last_commit), str(self.import_type), str(counter), "", "--encoding", "utf-8"])
+                               str(self.before_date), str(self.import_last_commit), str(self.import_type), str(counter), "", "--encoding", "utf-8"])
                     processes.append(p)
             else:
                 p = Popen(['python', 'git2db_reference.py', str(repo_id), reference[0], self.db_name, self.git_repo_path,
@@ -154,12 +171,12 @@ class Git2DbMain():
 
         minutes_and_seconds = divmod((end_time-start_time).total_seconds(), 60)
         self.logger.info("Git2Db: process finished after " + str(minutes_and_seconds[0])
-                     + " minutes and " + str(round(minutes_and_seconds[1], 1)) + " secs")
+                         + " minutes and " + str(round(minutes_and_seconds[1], 1)) + " secs")
         return
 
 
 def main():
-    a = Git2DbMain(config_db.PROJECT_NAME, config_db.DB_NAME, config_db.REPO_NAME, config_db.GIT_REPO_PATH, "", False, 1)
+    a = Git2DbMain(config_db.PROJECT_NAME, config_db.DB_NAME, config_db.REPO_NAME, config_db.GIT_REPO_PATH, "", False, 1, config_db)
     a.extract()
 
 if __name__ == "__main__":

--- a/extractor/init_db/init_dbschema.py
+++ b/extractor/init_db/init_dbschema.py
@@ -19,13 +19,32 @@ LOG_FOLDER = "logs"
 
 class InitDbSchema():
 
-    def __init__(self, db_name):
+    def __init__(self, config):
+        """
+        This constructor creates a new InitDbSchema but does not rely on an external config file. Instead, the config
+        information is passed as argument.
+
+        The config object has to comply with an structure similar to:
+        PROJECT_NAME = "<ProjectName>"
+        DB_NAME = "<Name to give to the database>"
+        REPO_NAME = "<Name to give to the repo>"
+        GIT_REPO_PATH = "<Path to the repo in disc>"
+        CONFIG = {
+            'user': 'DB_USER',
+            'password': 'DB_PASS',
+            'host': 'DB_HOST',
+            'port': 'DB_PORT',
+            'raise_on_warnings': False,
+            'buffered': True
+        }
+        :param config: The config object with the fields previously described
+        """
         self.db_name = config_db.DB_NAME
         self.create_log_folder(LOG_FOLDER)
         LOG_FILENAME = LOG_FOLDER + "/init_db_schema"
         self.delete_previous_logs(LOG_FOLDER)
         self.logger = logging.getLogger(LOG_FILENAME)
-        fileHandler = logging.FileHandler(LOG_FILENAME + "-" + db_name + ".log", mode='w')
+        fileHandler = logging.FileHandler(LOG_FILENAME + "-" + config_db.DB_NAME + ".log", mode='w')
         formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(message)s", "%Y-%m-%d %H:%M:%S")
 
         fileHandler.setFormatter(formatter)
@@ -784,7 +803,7 @@ class InitDbSchema():
 
 
 def main():
-    a = InitDbSchema(config_db.DB_NAME)
+    a = InitDbSchema(config_db)
     a.execute()
 
 if __name__ == "__main__":

--- a/extractor/init_db/init_dbschema.py
+++ b/extractor/init_db/init_dbschema.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 __author__ = 'valerio cosentino'
 
+import config_db # I had to change this import to the beginning to make everything work
 import sys
 sys.path.insert(0, "..//..")
 
 import mysql.connector
 from mysql.connector import errorcode
 from datetime import datetime
-import config_db
 import logging
 import logging.handlers
 import glob
@@ -21,14 +21,11 @@ class InitDbSchema():
 
     def __init__(self, config):
         """
-        This constructor creates a new InitDbSchema but does not rely on an external config file. Instead, the config
-        information is passed as argument.
+        This constructor creates a new InitDbSchema instance.
 
         The config object has to comply with an structure similar to:
-        PROJECT_NAME = "<ProjectName>"
+
         DB_NAME = "<Name to give to the database>"
-        REPO_NAME = "<Name to give to the repo>"
-        GIT_REPO_PATH = "<Path to the repo in disc>"
         CONFIG = {
             'user': 'DB_USER',
             'password': 'DB_PASS',
@@ -37,21 +34,22 @@ class InitDbSchema():
             'raise_on_warnings': False,
             'buffered': True
         }
+
         :param config: The config object with the fields previously described
         """
-        self.db_name = config_db.DB_NAME
+        self.db_name = config.DB_NAME
         self.create_log_folder(LOG_FOLDER)
         LOG_FILENAME = LOG_FOLDER + "/init_db_schema"
         self.delete_previous_logs(LOG_FOLDER)
         self.logger = logging.getLogger(LOG_FILENAME)
-        fileHandler = logging.FileHandler(LOG_FILENAME + "-" + config_db.DB_NAME + ".log", mode='w')
+        fileHandler = logging.FileHandler(LOG_FILENAME + "-" + config.DB_NAME + ".log", mode='w')
         formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(message)s", "%Y-%m-%d %H:%M:%S")
 
         fileHandler.setFormatter(formatter)
         self.logger.setLevel(logging.INFO)
         self.logger.addHandler(fileHandler)
 
-        self.cnx = mysql.connector.connect(**config_db.CONFIG)
+        self.cnx = mysql.connector.connect(**config.CONFIG)
 
     def create_log_folder(self, name):
         if not os.path.exists(name):
@@ -506,11 +504,11 @@ class InitDbSchema():
                                     ") ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;"
 
         insert_message_types = "INSERT INTO message_type VALUES (NULL, 'question'), " \
-                                                               "(NULL, 'answer'), " \
-                                                               "(NULL, 'comment'), " \
-                                                               "(NULL, 'accepted_answer'), " \
-                                                               "(NULL, 'reply'), " \
-                                                               "(NULL, 'file_upload');"
+                               "(NULL, 'answer'), " \
+                               "(NULL, 'comment'), " \
+                               "(NULL, 'accepted_answer'), " \
+                               "(NULL, 'reply'), " \
+                               "(NULL, 'file_upload');"
 
         create_table_attachment = "CREATE TABLE attachment ( " \
                                   "id int(20) PRIMARY KEY, " \


### PR DESCRIPTION
These changes allow Gitana processes involving database creation (i.e., `init_dbschema.py`) and Git population (i.e., `git2db_main.py`) to received all the required information to be launched as parameters. 

The `main` method has been also updated to keep backwards compatibility.
